### PR TITLE
Closes pages that has "opener".

### DIFF
--- a/src/lib/scrap.js
+++ b/src/lib/scrap.js
@@ -12,9 +12,25 @@ const browserPromise = puppeteer.launch({
   args: ['--no-sandbox', '--disable-setuid-sandbox'],
   // devtools: true,
 });
-browserPromise.then(() => {
+browserPromise.then(browser => {
   // eslint-disable-next-line no-console
   console.log(`Browser launched successfully.`);
+
+  // Some page may use window.open() to open extra pages.
+  // We should close them when such page is detected.
+  //
+  browser.on('targetcreated', async target => {
+    const opener = target.opener();
+    if (opener) {
+      // eslint-disable-next-line no-console
+      console.info(
+        `[targetcreated] Extra page "${target.url()}" opened by "${opener.url()}". Closing.`
+      );
+
+      const page = await target.page();
+      if (page) page.close();
+    }
+  });
 });
 
 const readabilityJsStr = fs.readFileSync(

--- a/src/resolvers/__tests__/__snapshots__/resolveUrls.test.js.snap
+++ b/src/resolvers/__tests__/__snapshots__/resolveUrls.test.js.snap
@@ -50,7 +50,7 @@ Object {
       },
       Object {
         "canonical": "",
-        "title": "宜家卡 - IKEA",
+        "title": "禮遇孕媽咪 登錄享專屬驚喜好禮｜IKEA－宜家卡",
         "url": "https://ikeabc.ecrm.com.tw/ikeaoa/l/11166",
       },
       Object {
@@ -182,7 +182,7 @@ Object {
         "url": "http://blog.udn.com/watercmd/1066441",
       },
       Object {
-        "canonical": "https://pension.president.gov.tw/cp.aspx?n=0710ED8C9356A871",
+        "canonical": "http://pension.president.gov.tw/cp.aspx?n=0710ED8C9356A871",
         "error": null,
         "summary": "網路流傳
 			
@@ -215,11 +215,11 @@ Object {
         "url": "https://pension.president.gov.tw/cp.aspx?n=0710ED8C9356A871",
       },
       Object {
-        "canonical": "https://www.fun123.com.tw/site/promote/download_app",
+        "canonical": "https://www.fun123.com.tw/site/promote/download_app?utm_source=app_daily_coupon&utm_medium=short&utm_campaign=download_app",
         "error": null,
         "summary": "流行3C周邊商品 限時特價",
         "title": "3C市集 | 流行3C周邊商品 限時特價",
-        "topImageUrl": "https://www.fun123.com.tw/images/desktop/downloadapp/fun123_downloadapp_banner.jpg",
+        "topImageUrl": "",
         "url": "http://ms7.tw/DL/D?k=app_daily_coupon",
       },
       Object {


### PR DESCRIPTION
This change detects when a page is opened by `window.open()` and closes it when detected.

Fixes #5 .

<img width="875" alt="2018-09-29 12 45 54" src="https://user-images.githubusercontent.com/108608/46241144-d566a080-c3e5-11e8-8f13-894dae9d4290.png">

`browserCount` confirmed to remain 1, so the extra page is properly closed:
```
{
  "data": {
    "browserStats": {
      "pageCount": 1,
      "pages": [
        {
          "title": "",
          "url": "about:blank",
          "metrics": {
            "JSHeapUsedSize": 1340992,
            "Nodes": 8,
            "Timestamp": 853622.164868
          }
        }
      ]
    },
    "resolvedUrls": []
  }
}
```

