### PR TITLE
ci: auto-build and push docker image to docker hub on master

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,46 @@
+name: Build and push to docker
+
+on:
+  push:
+    tags:
+      - release/*
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/release') && 'latest' || 'dev' }}
+
+    steps:
+      - name: Echo RELEASE_TAG
+        run: 'echo $RELEASE_TAG'
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: cofacts/url-resolver:${{ env.RELEASE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
The last image push to docker hub was 2020-06-10, six years ago. Manual `docker build && docker push` worked when the codebase changed once a year, but Node 12 + puppeteer 2.x going EOL means the image needs to keep moving and "the maintainer remembers to push" stops being a reliable mechanism.

Match the workflow shape cofacts/collab-server and cofacts/rumors-site already use, so org-level docker hub secrets, tag scheme, and trigger pattern are consistent across repos:

- Secret names: `DOCKER_HUB_USERNAME`, `DOCKER_HUB_ACCESS_TOKEN` (already set at org level for the other repos)
- master push        → `cofacts/url-resolver:dev`    (staging)
- git tag `release/*` → `cofacts/url-resolver:latest` (production)
- `workflow_dispatch` lets a maintainer trigger manually

The `release/*` git tag gate means a production publish is always an explicit human action, not a side effect of merging. To ship:

    git tag release/<yyyy-mm-dd> && git push origin release/<yyyy-mm-dd>

GitHub Actions cache (`type=gha`) reuses Docker layers across runs so subsequent pushes finish in ~1 minute instead of ~3.

## Verification

Login, checkout, and buildx steps pass against org-level Docker Hub secrets (verified via `workflow_dispatch` run #28280552411). End-to-end build verification pending re-trigger after rebase onto `feat/upgrade-deps`.

[Build](https://github.com/cofacts/url-resolver/actions/runs/28280833052) and pulled-tested locally passed.